### PR TITLE
[ch18867] WC 3.8 compatibility

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, sorting, product sorting, orderby
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@skyverge.com&item_name=Donation+for+WooCommerce+Extra+Product+Sorting
 Requires at least: 4.4
 Tested up to: 5.2.2
-Stable Tag: 2.8.0
+			Stable Tag: 2.8.1-dev.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -104,6 +104,9 @@ We removed randomized product sorting some time ago because it wasn't 100% funct
 Since this feature wasn't at 100%, we have removed it and turned it into a code snippet. If you need to re-add randomized sorting, please [use this code snippet](https://gist.github.com/bekarice/bac8b67064001ebc3bc2475424d99f87), ensuring that you [know how to add code to your site](http://skyverge.com/blog/add-custom-code-to-wordpress/).
 
 == Changelog ==
+
+= 2019.nn.nn - version 2.8.1-dev.1 =
+ * Misc - Add support for WooCommerce 3.8
 
 = 2019.08.15 - version 2.8.0
  * Misc: Add support for WooCommerce 3.7

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, sorting, product sorting, orderby
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@skyverge.com&item_name=Donation+for+WooCommerce+Extra+Product+Sorting
 Requires at least: 4.4
 Tested up to: 5.2.2
-			Stable Tag: 2.8.1-dev.1
+Stable Tag: 2.8.1-dev.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/woocommerce-extra-product-sorting-options.php
+++ b/woocommerce-extra-product-sorting-options.php
@@ -5,7 +5,7 @@
  * Description: Rename default sorting and optionally extra product sorting options.
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com/
- * Version: 2.8.0
+ * Version: 2.8.1-dev.1
  * Text Domain: woocommerce-extra-product-sorting-options
  * Domain Path: /i18n/languages/
  *
@@ -20,7 +20,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
  * WC requires at least: 3.0.9
- * WC tested up to: 3.7.0
+ * WC tested up to: 3.8.0
  */
 
 defined( 'ABSPATH' ) or exit;
@@ -45,7 +45,7 @@ class WC_Extra_Sorting_Options {
 
 
 	/** plugin version number */
-	const VERSION = '2.8.0';
+	const VERSION = '2.8.1-dev.1';
 
 	/** required WooCommerce version number */
 	const MIN_WOOCOMMERCE_VERSION = '3.0.9';


### PR DESCRIPTION
# Summary

This release adds support for WC 3.8.

### Stories

- [CH 18867](https://app.clubhouse.io/skyverge/story/18867/wc-3-8-compatibility)

## Details

Extra Product Sorting Options doesn't use the framework, so this is just a version bump & wc-tested-to bump.

## QA

- Activate WC Admin
- Activate Extra Product Sorting Options
- Configure settings (customizer)
- [x] Settings save correctly
- [x] Frontend sorting options are correctly updated & sort correctly when selected

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version