### PR TITLE
WC 3.9 Compatibility Release

### DIFF
--- a/includes/class-wc-eso-customizer-checkbox-multiple.php
+++ b/includes/class-wc-eso-customizer-checkbox-multiple.php
@@ -19,7 +19,7 @@
  *  upon which this class is based.
  *
  * @author    SkyVerge
- * @copyright Copyright (c) 2014-2019, SkyVerge, Inc.
+ * @copyright Copyright (c) 2014-2020, SkyVerge, Inc.
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,10 @@ WooCommerce Extra Product Sorting Options provides options that extend the defau
 
 ### Changelog
 
-**2019.08.13 - version 2.8.0**
+**2019.10.24 - version 2.8.1
+ * Misc - Add support for WooCommerce 3.8
+
+**2019.08.15 - version 2.8.0**
  * Misc: Add support for WooCommerce 3.7
  * Misc: Remove support for WooCommerce 2.6
  

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,9 @@ WooCommerce Extra Product Sorting Options provides options that extend the defau
 
 ### Changelog
 
+**2020.nn.nn - version 2.8.2-dev.1
+ * Misc - Add support for WooCommerce 3.9
+
 **2019.10.24 - version 2.8.1
  * Misc - Add support for WooCommerce 3.8
 

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,9 @@ Since this feature wasn't at 100%, we have removed it and turned it into a code 
 
 == Changelog ==
 
+= 2020.nn.nn - version 2.8.2-dev.1 =
+ * Misc - Add support for WooCommerce 3.9
+
 = 2019.10.24 - version 2.8.1 =
  * Misc - Add support for WooCommerce 3.8
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, sorting, product sorting, orderby
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@skyverge.com&item_name=Donation+for+WooCommerce+Extra+Product+Sorting
 Requires at least: 4.4
 Tested up to: 5.2.4
-Stable Tag: 2.8.1
+Stable Tag: 2.8.2-dev.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/woocommerce-extra-product-sorting-options.php
+++ b/woocommerce-extra-product-sorting-options.php
@@ -5,7 +5,7 @@
  * Description: Rename default sorting and optionally extra product sorting options.
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com/
- * Version: 2.8.1
+ * Version: 2.8.2-dev.1
  * Text Domain: woocommerce-extra-product-sorting-options
  * Domain Path: /i18n/languages/
  *
@@ -45,7 +45,7 @@ class WC_Extra_Sorting_Options {
 
 
 	/** plugin version number */
-	const VERSION = '2.8.1';
+	const VERSION = '2.8.2-dev.1';
 
 	/** required WooCommerce version number */
 	const MIN_WOOCOMMERCE_VERSION = '3.0.9';

--- a/woocommerce-extra-product-sorting-options.php
+++ b/woocommerce-extra-product-sorting-options.php
@@ -9,14 +9,14 @@
  * Text Domain: woocommerce-extra-product-sorting-options
  * Domain Path: /i18n/languages/
  *
- * Copyright: (c) 2014-2019, SkyVerge, Inc. (info@skyverge.com)
+ * Copyright: (c) 2014-2020, SkyVerge, Inc. (info@skyverge.com)
  *
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
  *
  * @author    SkyVerge
  * @category  Admin
- * @copyright Copyright (c) 2014-2019, SkyVerge, Inc.
+ * @copyright Copyright (c) 2014-2020, SkyVerge, Inc.
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
  * WC requires at least: 3.0.9


### PR DESCRIPTION
# Summary

This PR adds support for WooCommerce 3.9 and updates the copyright year to 2020.

### Stories

- [CH 24720](https://app.clubhouse.io/skyverge/story/24720/woocommerce-3-9-compatibility)

## Details

There were no incompatibilities with WC 3.9.

## Before merge

- [ ] I added a commit to replace `2020.nn.nn` with today's date in `readme.md`. Sake currently replaces that on `readme.txt` and `changelog.txt` only
- [ ] I have confirmed these changes in each supported minor WooCommerce version
