### PR TITLE
WooCommerce 4.1 compatibility

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,12 @@ WooCommerce Extra Product Sorting Options provides options that extend the defau
 
 ### Changelog
 
+**2020.nn.nn - version 2.8.4-dev.1
+ * Misc - Add support for WooCommerce 4.1
+
+**2020.03.10 - version 2.8.3
+ * Misc - Add support for WooCommerce 4.0
+
 **2020.02.05 - version 2.8.2
  * Misc - Add support for WooCommerce 3.9
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, sorting, product sorting, orderby
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@skyverge.com&item_name=Donation+for+WooCommerce+Extra+Product+Sorting
 Requires at least: 4.4
 Tested up to: 5.3.2
-Stable Tag: 2.8.3
+Stable Tag: 2.8.4-dev.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -104,6 +104,9 @@ We removed randomized product sorting some time ago because it wasn't 100% funct
 Since this feature wasn't at 100%, we have removed it and turned it into a code snippet. If you need to re-add randomized sorting, please [use this code snippet](https://gist.github.com/bekarice/bac8b67064001ebc3bc2475424d99f87), ensuring that you [know how to add code to your site](http://skyverge.com/blog/add-custom-code-to-wordpress/).
 
 == Changelog ==
+
+= 2020.nn.nn - version 2.8.4-dev.1 =
+ * Misc - Add support for WooCommerce 4.1
 
 = 2020.03.10 - version 2.8.3 =
  * Misc - Add support for WooCommerce 4.0

--- a/woocommerce-extra-product-sorting-options.php
+++ b/woocommerce-extra-product-sorting-options.php
@@ -5,7 +5,7 @@
  * Description: Rename default sorting and optionally extra product sorting options.
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com/
- * Version: 2.8.3
+ * Version: 2.8.4-dev.1
  * Text Domain: woocommerce-extra-product-sorting-options
  * Domain Path: /i18n/languages/
  *
@@ -45,7 +45,7 @@ class WC_Extra_Sorting_Options {
 
 
 	/** plugin version number */
-	const VERSION = '2.8.3';
+	const VERSION = '2.8.4-dev.1';
 
 	/** required WooCommerce version number */
 	const MIN_WOOCOMMERCE_VERSION = '3.0.9';


### PR DESCRIPTION
# Summary

This PR adds support to WC 4.1.

### Story: [CH 53182](https://app.clubhouse.io/skyverge/story/53182/woocommerce-4-1-compatibility)

## Details

There were no incompatibilities with WC 4.1.0-rc.2.

## QA

- [x] Add sorting options in customizer
- [x] Try sorting products in shop with new options

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version
- [ ] Jilt Promotions has been added